### PR TITLE
Pull in changes to avoid running the update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -119,4 +119,4 @@ jobs:
         body: |
           foreman-packaging update packages Github Action failed
 
-          ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
     - name: Checkout RPM
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: rpm/develop
     - name: Set the list
@@ -44,7 +44,7 @@ jobs:
         echo 'echo "$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>"' | sudo tee /usr/local/bin/rpmdev-packager
         sudo chmod +x /usr/local/bin/spectool /usr/local/bin/rpmdev-packager
     - name: Checkout RPM
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: rpm/develop
     - name: Initialize git annex
@@ -54,7 +54,7 @@ jobs:
       env:
         SKIP_GIT_COMMIT: 1
     - name: Open a PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         branch: "bump_rpm/${{ matrix.package_name }}"
@@ -70,7 +70,7 @@ jobs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
     - name: Checkout deb
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: deb/develop
     - name: Set the list
@@ -88,13 +88,13 @@ jobs:
         include: ${{ fromJson(needs.deb_list.outputs.matrix) }}
     steps:
     - name: Checkout DEB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: deb/develop
     - name: Update package
       run: ./scripts/update_package.rb --name "$(basename ${{ matrix.directory }})" --version "${{ matrix.new_version }}"
     - name: Open a PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: "Update ${{ matrix.package_name }} to ${{ matrix.new_version }}"
         branch: "bump_deb/${{ matrix.package_name }}"

--- a/.github/workflows/bump_packages.yml
+++ b/.github/workflows/bump_packages.yml
@@ -13,6 +13,7 @@ jobs:
   rpm_list:
     name: 'Gather RPMs'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'theforeman'
     outputs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:
@@ -64,6 +65,7 @@ jobs:
   deb_list:
     name: 'Gather debs'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'theforeman'
     outputs:
       matrix: ${{ steps.set_list.outputs.matrix }}
     steps:


### PR DESCRIPTION
Without this the weekly job runs to update package, but that's only relevant for Foreman itself. This should prevent the bunch of opened PRs.